### PR TITLE
Make garden-linux log level manifest configurable

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -104,3 +104,8 @@ properties:
 
   garden.no_proxy:
     description: List of comma-separated hosts that should skip connecting to the proxy
+
+  garden.log_level:
+    description: Level of logging for the Garden process
+    default: info
+

--- a/jobs/garden/templates/garden_ctl.erb
+++ b/jobs/garden/templates/garden_ctl.erb
@@ -175,6 +175,7 @@ case $1 in
       -rootfs=<%= p("garden.default_container_rootfs") %> \
       -containerGraceTime=<%= p("garden.default_container_grace_time") %> \
       -enableGraphCleanup=<%= p("garden.enable_graph_cleanup") %> \
+      -logLevel=<%= p("garden.log_level") %> \
     <% if_p("garden.docker_registry_endpoint") do |endpoint| %> \
       -registry=<%= endpoint %> \
     <% end %> \


### PR DESCRIPTION
Signed-off-by: James Myers <jmyers@pivotal.io>