### PR TITLE
Control script uses best effort for loop device creation

### DIFF
--- a/jobs/garden/templates/garden_ctl.erb
+++ b/jobs/garden/templates/garden_ctl.erb
@@ -63,9 +63,7 @@ function permit_device_control() {
 function create_loop_devices() {
   amt=${1:-256}
   for i in $(seq 0 $amt); do
-    if ! mknod -m 0660 /dev/loop$i b 7 $i; then
-      break
-    fi
+    mknod -m 0660 /dev/loop$i b 7 $i || true
   done
 }
 


### PR DESCRIPTION
*  `mknod` fails if the loopback device already exists

Signed-off-by: Connor Braa <cbraa@pivotal.io>