### PR TITLE
do not use tiny default bosh stemcell /tmp

### DIFF
--- a/jobs/garden/templates/garden_ctl.erb
+++ b/jobs/garden/templates/garden_ctl.erb
@@ -85,6 +85,9 @@ case $1 in
     mkdir -p $RUN_DIR
     mkdir -p $DATA_DIR
     mkdir -p $LOG_DIR
+    
+    export TMPDIR=/var/vcap/data/tmp
+    mkdir -p $TMPDIR
 
     export PATH=/var/vcap/packages/shadow/sbin:$PATH
     export PATH=/var/vcap/packages/iptables/sbin:$PATH


### PR DESCRIPTION
By default, BOSH creates a tiny `/tmp` dir, we should use the `/var/vcap/data/...` one instead. Setting this environment variable will cause [Go to use it][1].

This hasn't been a problem before because Garden wasn't putting anything in the temporary directory until the verifier stuff in `garden-shed`.

This is the error that we are seeing with Garden versions 0.326.0+:

```
{"timestamp":"1447364856.447069168","source":"garden-linux","message":"garden-linux.pool.acquire.provide-rootfs-failed","log_level":2,"data":{"error":"write /tmp/703473976: no space left on device","handle":"5g9q46mchlb","session":"8.104"}}
```

[1]: https://golang.org/src/os/file_unix.go?s=9116:9137#L319