### PR TITLE
Allow overriding DNS servers in containers

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -84,6 +84,10 @@ properties:
   garden.dropsonde.destination:
     description: "a URL that points at the Metron agent to which metrics are forwarded. By default, it matches with the default of Metron."
 
+  garden.dns_servers:
+    description: Override DNS servers to be used in containers; defaults to the same as the host
+    default: []
+
   garden.http_proxy:
     description: http proxy that the Garden server process will use
 

--- a/jobs/garden/templates/garden_ctl.erb
+++ b/jobs/garden/templates/garden_ctl.erb
@@ -161,6 +161,9 @@ case $1 in
     <% p("garden.persistent_image_list").each do |url| %> \
       -persistentImage=<%= url %> \
     <% end %> \
+    <% p("garden.dns_servers").each do |server| %> \
+      -dnsServer=<%= server %> \
+    <% end %> \
       1>>$LOG_DIR/garden.stdout.log \
       2>>$LOG_DIR/garden.stderr.log
 


### PR DESCRIPTION
See cloudfoundry-incubator/garden-linux#60 / cloudfoundry-incubator/guardian-release#7

Matching garden-linux PR in cloudfoundry-incubator/garden-linux#61