### PR TITLE
Implement logic to send service logs to syslog

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -106,3 +106,7 @@ properties:
   garden.debug_listen_address:
     description: "tcp address on which to serve debug info"
     default: "0.0.0.0:17013"
+
+  garden.log_to_syslog:
+    description: "Set this to True to enable logging to syslog."
+    default: False

--- a/jobs/garden/templates/garden_ctl.erb
+++ b/jobs/garden/templates/garden_ctl.erb
@@ -115,6 +115,14 @@ case $1 in
 
     echo $$ > $PIDFILE
 
+    <% if p('garden.log_to_syslog') %>
+    exec 1> >( tee -a $LOG_DIR/garden.stdout.log | logger -t vcap.garden.stdout ) \
+         2> >( tee -a $LOG_DIR/garden.stderr.log | logger -t vcap.garden.stderr )
+    <% else %>
+    exec 1>>$LOG_DIR/garden.stdout.log \
+         2>>$LOG_DIR/garden.stderr.log
+    <% end %>
+
     exec /var/vcap/packages/garden-linux/bin/garden-linux \
       -depot=/var/vcap/data/garden/depot \
       -snapshots="${snapshots_path}" \
@@ -163,9 +171,7 @@ case $1 in
     <% end %> \
     <% p("garden.dns_servers").each do |server| %> \
       -dnsServer=<%= server %> \
-    <% end %> \
-      1>>$LOG_DIR/garden.stdout.log \
-      2>>$LOG_DIR/garden.stderr.log
+    <% end %>
 
     ;;
 


### PR DESCRIPTION
# Motivation

Several of the CF and Diego platform services send logs to the local syslog, tagged as `vcap.*`. . The [metron agent from loggregrator configures the local syslog to send the logs to metron](https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/spec#L29) so that later can be sent to a centralised logging service. 

In some cases it is the service application itself who sends the logs to syslog, but it seems to be a common pattern across CF and Diego services to [let the service log to stdout/stderr, and redirect that output to local files or syslog](https://github.com/cloudfoundry/diego-release/blob/develop/jobs/bbs/templates/bbs_as_vcap.erb#L91) using the [`logger` command](http://linux.die.net/man/1/logger). 

Not all the services implement this feature, and instead they only log to local files. In order to centralise all the logs, so we will add the logic required to send the logs of the missing services. 

We will implement the _log to stdout and redirect  to `logger` pattern_ whenever is possible.
## Implementation in garden-linux release

We add a property `garden.log_to_syslog`. When true, we redirect the stdout and stderr in the ctl script into syslog following the standard vcap pattern, in addition to files.

The logs from garden are already in json parseable format and redirected to log files. We only add the additional code to redirect to `logger`
## How to review?

Enable the `garden.log_to_syslog` and deploy. Logs should be sent to syslog. If metron agent is installed locally, the logs will be redirected to metron agent the loggregrator.
## Open questions

This PR is open to debate with several open questions:
- Is OK to add a specific property to enable nats logs to syslog? or should this be enabled by default?
- shall we spawn `logger` and `tee` with the vcap user [as they do in diego?](https://github.com/cloudfoundry/diego-release/blob/develop/jobs/bbs/templates/bbs_as_vcap.erb)
